### PR TITLE
fix: change cpu governor to ondemand

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -43,7 +43,7 @@ main() {
     cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor >"$USERDATA_PATH/NDS-advanced-drastic/cpu_governor.txt"
     cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq >"$USERDATA_PATH/NDS-advanced-drastic/cpu_min_freq.txt"
     cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq >"$USERDATA_PATH/NDS-advanced-drastic/cpu_max_freq.txt"
-    echo performance >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+    echo ondemand >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
     echo 1608000 >/sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
     echo 1800000 >/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
 


### PR DESCRIPTION
Switched the default CPU governor to ondemand instead of performance. Ondemand ramps up the CPU when needed, but saves battery and keeps things cool when not much is happening. It will help the brick last longer and avoid overheating, but still give good performance when running games.