### PR TITLE
perf(cpu): optimize cpu frequency scaling in launch script

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -46,6 +46,10 @@ nds_cpu_configure() {
     case $1 in
         performance)
             echo "$1" >"$SYSTEM_CPU_POLICY0/$CPU_SCALING_GOVERNOR" || true
+            echo "$PREFER_CPU_FREQ" >"$SYSTEM_CPU_POLICY0/scaling_max_freq" || true
+            ;;
+        ondemand)
+            echo "$1" >"$SYSTEM_CPU_POLICY0/$CPU_SCALING_GOVERNOR" || true
             echo "$MIN_CPU_FREQ" >"$SYSTEM_CPU_POLICY0/scaling_min_freq" || true
             echo "$PREFER_CPU_FREQ" >"$SYSTEM_CPU_POLICY0/scaling_max_freq" || true
             ;;
@@ -111,7 +115,7 @@ main() {
     cat "$SYSTEM_CPU_POLICY0/$CPU_SCALING_MAX_FREQ" >"$TEMP_SCALING_MAX_FREQ"
 
     # Predefined cpu profile for drastic
-    nds_cpu_configure performance
+    nds_cpu_configure ondemand
     nds_buffer_size_patch
 
     if [ -d "$EMU_DIR/cheats" ]; then


### PR DESCRIPTION
The current performance CPU governor although keep game run smooth but has make the device became so hot after a long play session. After some days tried and error, and now the root source of audio issue is gone, I have make a small change to change back to ondemand governor. The result:
- Most game instead of run with 16800Mhz now with default config only run with 81900 or max 12000MHz(lower cpu load -> less battery drain)
- After a long play session, the heat is not as high as before and more manageable
- Most game still functioning and sound great

Game that have been test for at least 30 minutes:
- Avalon Code
- Contra 4
- CTGP Nitro (Mario Kart DS hacks)
- Dragon Ball - Origins 2

P/s: Some caveat, if the game is resume from sleep or a long time from menu, there will be a little stutters and then the cpu will keep up just after that