### PR TITLE
feat: add support for h700 based devices

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 .gitarchiveinclude export-ignore
 .gitignore export-ignore
 Makefile export-ignore
+test export-ignore

--- a/.github/linters/.markdown-lint.yaml
+++ b/.github/linters/.markdown-lint.yaml
@@ -1,0 +1,6 @@
+---
+default: true
+
+# Line length
+# https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md013
+MD013: false

--- a/.github/linters/.yamllint.yaml
+++ b/.github/linters/.yamllint.yaml
@@ -1,0 +1,5 @@
+---
+extends: default
+
+rules:
+  line-length: disable

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,63 @@
+---
+name: "lint"
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "main"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  markdown-lint:
+    name: markdown-lint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clone
+        uses: actions/checkout@v7
+      - name: Run markdown-lint
+        uses: avto-dev/markdown-lint@04d43ee9191307b50935a753da3b775ab695eceb
+        with:
+          config: ".github/linters/.markdown-lint.yaml"
+          args: "./README.md"
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clone
+        uses: actions/checkout@v7
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
+        env:
+          SHELLCHECK_OPTS: -s sh
+
+  shfmt:
+    name: shfmt
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clone
+        uses: actions/checkout@v7
+      - name: Run shfmt
+        uses: luizm/action-sh-checker@17bd25a6ee188d2b91f677060038f4ba37ba14b2
+        env:
+          SHFMT_OPTS: -l -d -i 4
+        with:
+          sh_checker_shellcheck_disable: true
+
+  yamllint:
+    name: yamllint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clone
+        uses: actions/checkout@v7
+      - name: Run yamllint
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c
+        with:
+          config_file: ".github/linters/.yamllint.yaml"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,31 @@
+---
+name: "test"
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "main"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bats:
+    name: bats
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clone
+        uses: actions/checkout@v7
+
+      - name: Install bats
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats
+
+      - name: Run tests
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 dist
+tmp
 bin/*
 !bin/.gitkeep
 res/fonts/*
 !res/fonts/.gitkeep
-!bin/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PAK_FOLDER := $(shell echo $(PAK_TYPE) | cut -c1)$(shell echo $(PAK_TYPE) | tr '
 PUSH_SDCARD_PATH ?= /mnt/SDCARD
 PUSH_PLATFORM ?= tg5040
 
-PLATFORMS := tg5040
+PLATFORMS := h700 tg5040 tg5050
 
 MINUI_POWER_CONTROL_VERSION := 1.1.0
 UNZIP_DEB_URL := https://archive.debian.org/debian/pool/main/u/unzip/unzip_6.0-23+deb10u2_arm64.deb
@@ -29,6 +29,13 @@ bin/unzip:
 	chmod +x bin/unzip
 	rm -rf $(UNZIP_TMP)
 
+lint:
+	shellcheck -s sh launch.sh
+	shfmt -l -d -i 4 launch.sh test/launch.bats
+
+test:
+	bats test
+
 release: build
 	mkdir -p dist
 	git archive --format=zip --output "dist/$(PAK_NAME).pak.zip" HEAD
@@ -45,3 +52,5 @@ push: release
 	rm -rf "dist/$(PAK_NAME).pak"
 	cd dist && unzip "$(PAK_NAME).pak.zip" -d "$(PAK_NAME).pak"
 	adb push "dist/$(PAK_NAME).pak/." "$(PUSH_SDCARD_PATH)/$(PAK_FOLDER)/$(PUSH_PLATFORM)/$(PAK_NAME).pak"
+
+.PHONY: build clean lint push release test

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ A MinUI Emu Pak for Nintendo DS, wrapping the standalone Advanced Drastic Ninten
 This pak is designed and tested on the following MinUI Platforms and devices:
 
 - `tg5040`: Trimui Brick (formerly `tg3040`) and Trimui Smart Pro
+- `tg5050`: Trimui Smart Pro S
+- `h700`: Anbernic RG28XX, RG34XX, RG34XX SP, RG35XX Plus, RG35XX 2024, RG35XX H, RG35XX Pro, RG35XX SP, RG40XX H, RG40XX V, RG Cube XX and RG SP
 
-Use the correct platform for your device.
+Use the correct platform for your device. The `h700` and `tg5050` platforms are provided by NextUI, so those devices need NextUI rather than stock MinUI.
 
 ## Installation
 
@@ -20,6 +22,25 @@ Use the correct platform for your device.
 6. Create a folder at `/Roms/Nintendo DS (NDS)` and place your roms in this directory.
 7. Unmount your SD Card and insert it into your MinUI device.
 
+## Device Configuration
+
+Advanced Drastic ships a separate configuration per device, and they differ in screen orientation and button mapping. On the first launch the pak picks the profile that matches your device and copies it into `drastic/config/`, then records the choice in `/.userdata/$PLATFORM/NDS-advanced-drastic/device.txt`. The previous configuration is kept alongside it as `drastic.cfg.bak`.
+
+| Device | Profile |
+| --- | --- |
+| Trimui Brick, Trimui Brick Pro | `trimui-brick` |
+| Trimui Smart Pro, Trimui Smart Pro S | `trimui-smart-pro` |
+| RG28XX | `rg28xx` |
+| RG35XX SP | `rg35xx-sp` |
+| RG40XX V | `rg40xx-v` |
+| RG Cube XX | `rg-cubexx` |
+| RG34XX SP, RG35XX H, RG35XX Pro, RG40XX H | `rg40xx-h` |
+| RG34XX, RG35XX Plus, RG35XX 2024, RG SP | `rg35xx-sp` |
+
+Devices without a profile of their own use the closest one, chosen by whether the device has analog sticks.
+
+Seeding only happens once per device, so any remapping done inside the Drastic settings menu is kept on later launches. Delete `device.txt` to have the profile applied again.
+
 ## Key Controls
 
 - L2: Toggle stylus / dpad
@@ -30,7 +51,7 @@ Use the correct platform for your device.
 - Select + Right: Increase layout index
 - Select + Y: Change themes
 - Select + B: Toggle blur / pixel mode
-- Select + Start: Display steward custom settings
+- Select + Start: Display steward custom settings (Trimui Brick only)
 - Select + L: Quick load
 - Select + R: Quick save
 
@@ -38,10 +59,19 @@ Use the correct platform for your device.
 
 Deep sleep is supported on compatible devices. Click the power button to enter deep sleep. Click again to resume the game. To shut down, hold the power button for 2 seconds. **Note:** Shutdown does not save or resume the game and any unsaved progress will be lost. For more information and issues, see [MinUI Power Control](https://github.com/ben16w/minui-power-control).
 
+MinUI Power Control does not support `h700` yet, so the power button keeps its default behaviour on those devices.
+
 ## Saves & States
 
 - Save states are stored in the `/.userdata/shared/NDS-advanced-drastic/` directory.
 - Game saves are stored in the `/Saves/NDS/` directory.
+
+## Development
+
+- `make build` downloads the bundled binaries into `bin/`.
+- `make lint` runs shellcheck against `launch.sh`.
+- `make test` runs the [bats](https://github.com/bats-core/bats-core) suite in `test/`.
+- `make release` produces `dist/NDS.pak.zip`.
 
 ## Credits
 

--- a/launch.sh
+++ b/launch.sh
@@ -1,97 +1,278 @@
 #!/bin/sh
-set -euxo pipefail
-rm -f "$LOGS_PATH/NDS.txt"
-exec >>"$LOGS_PATH/NDS.txt" 2>&1
 
-echo "$0" "$@"
-
-EMU_DIR="$SDCARD_PATH/Emus/$PLATFORM/NDS.pak/drastic"
-PACK_DIR="$SDCARD_PATH/Emus/$PLATFORM/NDS.pak"
-BRICK_DEVICE_DIR="$EMU_DIR/devices/trimui-brick"
-
-SYSTEM_CPU_DIR="/sys/devices/system/cpu/cpufreq"
-# NOTE:(2026-03-29 11:08:18 +07)Most low-end handled devices using share frequency on all core(policy0 affect all available cores). Setting everything here is more than enough
-SYSTEM_CPU_POLICY0="$SYSTEM_CPU_DIR/policy0"
-# NOTE:(2026-03-29 11:08:09 +07)Instead of hardcoding the min/max frequency, we can read it from the system then using awk to pick our desired frequency
-AVAILABLE_CPU_FREQS=$(cat "$SYSTEM_CPU_POLICY0/scaling_available_frequencies")
-MIN_CPU_FREQ=$(echo "$AVAILABLE_CPU_FREQS" | awk '{print $1}')
-MAX_CPU_FREQ=$(echo "$AVAILABLE_CPU_FREQS" | awk '{print $NF}')
-
-# NOTE:(2026-03-29 10:43:28 +07) After intense testing for best cpu freq, 1608000 come with perfect balance for efficient and performance. For any device with cpu freq below 1608000, we will use the max freq instead
-PREFER_CPU_FREQ=$(echo "$AVAILABLE_CPU_FREQS" | awk '{for(i=1;i<=NF;i++) if($i<=1608000) val=$i} END{print val}')
-
-NDS_MINUI_SAVE="$SDCARD_PATH/Saves/NDS"
-NDS_MINUI_CHEAT="$SDCARD_PATH/Cheats/NDS"
 NDS_USERDATA_NAME="NDS-advanced-drastic"
-NDS_USERDATA_DIR="$USERDATA_PATH/$NDS_USERDATA_NAME"
-NDS_SHARE_USERDATA_DIR="$SHARED_USERDATA_PATH/$NDS_USERDATA_NAME"
 
 TEMP_PREFIX=system_
 CPU_SCALING_GOVERNOR=scaling_governor
 CPU_SCALING_MIN_FREQ=scaling_min_freq
 CPU_SCALING_MAX_FREQ=scaling_max_freq
-TEMP_SCALING_FILE="$NDS_USERDATA_DIR/$TEMP_PREFIX$CPU_SCALING_GOVERNOR.txt"
-TEMP_SCALING_MIN_FREQ="$NDS_USERDATA_DIR/$TEMP_PREFIX$CPU_SCALING_MIN_FREQ.txt"
-TEMP_SCALING_MAX_FREQ="$NDS_USERDATA_DIR/$TEMP_PREFIX$CPU_SCALING_MAX_FREQ.txt"
 
-TEMP_ROM_DIR=$(mktemp -d /tmp/nds_rom_XXXXXX)
+# NOTE:(2026-03-29 11:08:18 +07)Most low-end handled devices using share frequency on all core(policy0 affect all available cores). Setting everything here is more than enough
+# Kernels differ on where they expose that policy, so probe both known locations.
+NDS_CPU_POLICY_DIRS="/sys/devices/system/cpu/cpufreq/policy0 /sys/devices/system/cpu/cpu0/cpufreq"
 
-export PATH="$EMU_DIR:$PACK_DIR/bin:$PATH"
-export LD_LIBRARY_PATH="$EMU_DIR/libs:$PACK_DIR/lib:$LD_LIBRARY_PATH"
-export HOME="$EMU_DIR"
+# NOTE:(2026-03-29 10:43:28 +07) After intense testing for best cpu freq, 1608000 come with perfect balance for efficient and performance. For any device with cpu freq below 1608000, we will use the max freq instead
+NDS_PREFERRED_CPU_FREQ=1608000
+
+# minui-power-control refuses to start outside this list, so h700 gets no deep sleep yet
+NDS_POWER_CONTROL_PLATFORMS="tg5040 tg5050 my355 rg35xxplus miyoomini"
+
+# NextUI reports the Trimui Brick as tg5040 with DEVICE=brick. Older MinUI builds
+# reported it as its own tg3040 platform with no DEVICE at all.
+nds_normalize_platform() {
+    if [ "${PLATFORM:-}" = "tg3040" ] && [ -z "${DEVICE:-}" ]; then
+        PLATFORM="tg5040"
+        DEVICE="brick"
+        export PLATFORM DEVICE
+    fi
+}
+
+nds_init_env() {
+    PACK_DIR="$SDCARD_PATH/Emus/$PLATFORM/NDS.pak"
+    EMU_DIR="$PACK_DIR/drastic"
+    BRICK_DEVICE_DIR="$EMU_DIR/devices/trimui-brick"
+
+    NDS_MINUI_SAVE="$SDCARD_PATH/Saves/NDS"
+    NDS_MINUI_CHEAT="$SDCARD_PATH/Cheats/NDS"
+    NDS_USERDATA_DIR="$USERDATA_PATH/$NDS_USERDATA_NAME"
+    NDS_SHARE_USERDATA_DIR="$SHARED_USERDATA_PATH/$NDS_USERDATA_NAME"
+    NDS_DEVICE_FILE="$NDS_USERDATA_DIR/device.txt"
+
+    TEMP_SCALING_FILE="$NDS_USERDATA_DIR/$TEMP_PREFIX$CPU_SCALING_GOVERNOR.txt"
+    TEMP_SCALING_MIN_FREQ="$NDS_USERDATA_DIR/$TEMP_PREFIX$CPU_SCALING_MIN_FREQ.txt"
+    TEMP_SCALING_MAX_FREQ="$NDS_USERDATA_DIR/$TEMP_PREFIX$CPU_SCALING_MAX_FREQ.txt"
+
+    export PATH="$EMU_DIR:$PACK_DIR/bin:$PATH"
+    export LD_LIBRARY_PATH="$EMU_DIR/libs:$PACK_DIR/lib:${LD_LIBRARY_PATH:-}"
+    export HOME="$EMU_DIR"
+}
+
+nds_cpu_policy_dir() {
+    for dir in $NDS_CPU_POLICY_DIRS; do
+        if [ -r "$dir/scaling_available_frequencies" ]; then
+            echo "$dir"
+            return 0
+        fi
+    done
+}
+
+nds_cpu_min_freq() {
+    echo "$1" | awk '{for(i=1;i<=NF;i++) if(min=="" || $i<min) min=$i} END{print min}'
+}
+
+# NOTE:(2026-03-29 11:08:09 +07)Instead of hardcoding the min/max frequency, we can read it from the system then using awk to pick our desired frequency
+nds_cpu_prefer_freq() {
+    echo "$1" | awk -v limit="$NDS_PREFERRED_CPU_FREQ" '
+        {
+            for (i = 1; i <= NF; i++) {
+                if (max == "" || $i > max) max = $i
+                if ($i <= limit && (val == "" || $i > val)) val = $i
+            }
+        }
+        END { print (val == "" ? max : val) }'
+}
 
 # NOTE: (2026-03-29 10:49:44 +07)For future researcher, if you have better idea for cpu governor, feel free to add it here. trngaje-advance-drastic current implementation with heavier game or normal game will never use that much cpu load(mostly highest will be ~50%) except when fast forward is toggle. Beside that, especially when using anything but performance governor, when you access menu and wait for a while(cool down cpu load, the current freq now will be the MIN_CPU_FREQ) and resume back, the game cpu freq will be stuck at that $MIN_CPU_FREQ until you reset the game -> stick to one freq and the highest one, which mean performance governor is the best match.
 nds_cpu_configure() {
+    if [ -z "${CPU_POLICY_DIR:-}" ]; then
+        echo "No cpufreq policy directory available, leaving the governor alone"
+        return 0
+    fi
+
+    available_freqs="$(cat "$CPU_POLICY_DIR/scaling_available_frequencies")"
+
     echo "Custom setting for $1 governor"
     case $1 in
-        performance)
-            echo "$1" >"$SYSTEM_CPU_POLICY0/$CPU_SCALING_GOVERNOR" || true
-            echo "$PREFER_CPU_FREQ" >"$SYSTEM_CPU_POLICY0/scaling_max_freq" || true
-            ;;
-        ondemand)
-            echo "$1" >"$SYSTEM_CPU_POLICY0/$CPU_SCALING_GOVERNOR" || true
-            echo "$MIN_CPU_FREQ" >"$SYSTEM_CPU_POLICY0/scaling_min_freq" || true
-            echo "$PREFER_CPU_FREQ" >"$SYSTEM_CPU_POLICY0/scaling_max_freq" || true
-            ;;
-        *)
-            echo "Unsupported governor: $1"
-            ;;
+    performance)
+        echo "$1" >"$CPU_POLICY_DIR/$CPU_SCALING_GOVERNOR" || true
+        nds_cpu_prefer_freq "$available_freqs" >"$CPU_POLICY_DIR/$CPU_SCALING_MAX_FREQ" || true
+        ;;
+    ondemand)
+        echo "$1" >"$CPU_POLICY_DIR/$CPU_SCALING_GOVERNOR" || true
+        nds_cpu_min_freq "$available_freqs" >"$CPU_POLICY_DIR/$CPU_SCALING_MIN_FREQ" || true
+        nds_cpu_prefer_freq "$available_freqs" >"$CPU_POLICY_DIR/$CPU_SCALING_MAX_FREQ" || true
+        ;;
+    *)
+        echo "Unsupported governor: $1"
+        ;;
     esac
+}
+
+nds_cpu_save_setting() {
+    source_path="$CPU_POLICY_DIR/$1"
+    target_path="$2"
+
+    rm -f "$target_path"
+    [ -r "$source_path" ] || return 0
+    cat "$source_path" >"$target_path"
+}
+
+nds_cpu_restore_setting() {
+    source_path="$1"
+    target_path="$CPU_POLICY_DIR/$2"
+
+    [ -f "$source_path" ] || return 0
+    cat "$source_path" >"$target_path" || true
+    rm -f "$source_path"
+}
+
+nds_cpu_save_state() {
+    [ -n "${CPU_POLICY_DIR:-}" ] || return 0
+
+    nds_cpu_save_setting "$CPU_SCALING_GOVERNOR" "$TEMP_SCALING_FILE"
+    nds_cpu_save_setting "$CPU_SCALING_MIN_FREQ" "$TEMP_SCALING_MIN_FREQ"
+    nds_cpu_save_setting "$CPU_SCALING_MAX_FREQ" "$TEMP_SCALING_MAX_FREQ"
+}
+
+nds_cpu_restore_state() {
+    [ -n "${CPU_POLICY_DIR:-}" ] || return 0
+
+    nds_cpu_restore_setting "$TEMP_SCALING_FILE" "$CPU_SCALING_GOVERNOR"
+    nds_cpu_restore_setting "$TEMP_SCALING_MIN_FREQ" "$CPU_SCALING_MIN_FREQ"
+    nds_cpu_restore_setting "$TEMP_SCALING_MAX_FREQ" "$CPU_SCALING_MAX_FREQ"
 }
 
 nds_buffer_size_patch() {
     echo "Custom setting for $PLATFORM"
     case $PLATFORM in
-        tg5040)
-            export ALSA_CONFIG_PATH="$BRICK_DEVICE_DIR/alsa/nds_alsa.conf"
-            export ALSA_ASOUNDRC="$BRICK_DEVICE_DIR/alsa/.asoundrc"
-            ;;
-        *)
-            echo "Unsupported platform: $PLATFORM"
-            ;;
+    tg5040)
+        export ALSA_CONFIG_PATH="$BRICK_DEVICE_DIR/alsa/nds_alsa.conf"
+        export ALSA_ASOUNDRC="$BRICK_DEVICE_DIR/alsa/.asoundrc"
+        ;;
+    *)
+        echo "Unsupported platform: $PLATFORM"
+        ;;
     esac
+}
 
+# Advanced DraStic ships a config per device under drastic/devices. They differ in
+# screen orientation and in the SDL joystick button block, so the wrong one leaves the
+# device with unusable controls. h700 devices without their own profile fall back to
+# the closest sibling, picked by whether the device has analog sticks.
+nds_device_profile() {
+    platform="${1:-}"
+    device="${2:-}"
+
+    case "$platform" in
+    h700)
+        case "$device" in
+        rg28xx) echo "rg28xx" ;;
+        rg35xxsp) echo "rg35xx-sp" ;;
+        rg40xxv) echo "rg40xx-v" ;;
+        rgcubexx) echo "rg-cubexx" ;;
+        rg40xxh | rg35xxh | rg35xxpro | rg34xxsp) echo "rg40xx-h" ;;
+        *) echo "rg35xx-sp" ;;
+        esac
+        ;;
+    tg5050)
+        echo "trimui-smart-pro"
+        ;;
+    *)
+        case "$device" in
+        smartpro) echo "trimui-smart-pro" ;;
+        *) echo "trimui-brick" ;;
+        esac
+        ;;
+    esac
+}
+
+# Seed once per device so that remapping done inside the DraStic settings menu survives
+# later launches. The previous config is kept next to the marker file.
+nds_seed_device_config() {
+    profile="$1"
+    profile_dir="$EMU_DIR/devices/$profile"
+
+    if [ ! -d "$profile_dir" ]; then
+        echo "No DraStic profile named $profile, keeping the shipped config"
+        return 0
+    fi
+
+    if [ -f "$NDS_DEVICE_FILE" ] && [ "$(cat "$NDS_DEVICE_FILE")" = "$profile" ]; then
+        return 0
+    fi
+
+    echo "Seeding DraStic config from the $profile profile"
+
+    if [ -f "$EMU_DIR/config/drastic.cfg" ]; then
+        cp -f "$EMU_DIR/config/drastic.cfg" "$NDS_USERDATA_DIR/drastic.cfg.bak"
+    fi
+
+    for name in drastic.cfg drastic.cf2; do
+        if [ -f "$profile_dir/config/$name" ]; then
+            cp -f "$profile_dir/config/$name" "$EMU_DIR/config/$name"
+        fi
+    done
+
+    if [ -f "$profile_dir/resources/settings.json" ]; then
+        cp -f "$profile_dir/resources/settings.json" "$EMU_DIR/resources/settings.json"
+    fi
+
+    echo "$profile" >"$NDS_DEVICE_FILE"
+}
+
+nds_config_set() {
+    config_path="$1"
+    key="$2"
+    value="$3"
+
+    awk -v key="$key" -v value="$value" '
+        $0 ~ "^" key " *=" { print key " = " value; next }
+        { print }' "$config_path" >"$config_path.tmp"
+    mv -f "$config_path.tmp" "$config_path"
+}
+
+# The pak bind mounts Saves/NDS onto the emulator backup directory, so saves have to be
+# written in .sav format. Some device profiles ship 0, which writes .dsv instead.
+nds_sav_format_patch() {
+    config_path="$EMU_DIR/config/drastic.cfg"
+    [ -f "$config_path" ] || return 0
+
+    nds_config_set "$config_path" backup_use_sav_format 1
+}
+
+# Cheats dropped into the pak get moved out to the shared MinUI cheats directory before
+# that directory is bind mounted over the top of them.
+nds_migrate_cheats() {
+    [ -d "$EMU_DIR/cheats" ] || return 0
+
+    for cheat in "$EMU_DIR/cheats/"*; do
+        [ -e "$cheat" ] || continue
+        mv -f "$cheat" "$NDS_MINUI_CHEAT/" || true
+    done
+}
+
+# Extract zip ROMs to a temp directory before launching
+nds_resolve_rom_path() {
+    NDS_ROM_PATH="$1"
+
+    case "$(echo "$NDS_ROM_PATH" | tr '[:upper:]' '[:lower:]')" in
+    *.zip)
+        TEMP_ROM_DIR="$(mktemp -d /tmp/nds_rom_XXXXXX)"
+        "$PACK_DIR/bin/unzip" -o "$NDS_ROM_PATH" -d "$TEMP_ROM_DIR"
+        NDS_ROM_PATH="$(find "$TEMP_ROM_DIR" -name "*.nds" | head -1)"
+        ;;
+    esac
+}
+
+nds_start_power_control() {
+    for platform in $NDS_POWER_CONTROL_PLATFORMS; do
+        if [ "$platform" = "$PLATFORM" ]; then
+            minui-power-control drastic &
+            return 0
+        fi
+    done
+
+    echo "minui-power-control does not support $PLATFORM, deep sleep is unavailable"
 }
 
 cleanup() {
     rm -f /tmp/stay_awake
 
-    if [ -n "$TEMP_ROM_DIR" ] && [ -d "$TEMP_ROM_DIR" ]; then
+    if [ -n "${TEMP_ROM_DIR:-}" ] && [ -d "$TEMP_ROM_DIR" ]; then
         rm -rf "$TEMP_ROM_DIR"
     fi
 
-    if [ -f "$TEMP_SCALING_FILE" ]; then
-        cat "$TEMP_SCALING_FILE" >"$SYSTEM_CPU_POLICY0/$CPU_SCALING_GOVERNOR" || true
-        rm -f "$TEMP_SCALING_FILE"
-    fi
-    if [ -f "$TEMP_SCALING_MIN_FREQ" ]; then
-        cat "$TEMP_SCALING_MIN_FREQ" >"$SYSTEM_CPU_POLICY0/$CPU_SCALING_MIN_FREQ" || true
-        rm -f "$TEMP_SCALING_MIN_FREQ"
-    fi
-    if [ -f "$TEMP_SCALING_MAX_FREQ" ]; then
-        cat "$TEMP_SCALING_MAX_FREQ" >"$SYSTEM_CPU_POLICY0/$CPU_SCALING_MAX_FREQ" || true
-        rm -f "$TEMP_SCALING_MAX_FREQ"
-    fi
+    nds_cpu_restore_state
 
     umount "$EMU_DIR/backup" || true
     umount "$EMU_DIR/cheats" || true
@@ -99,6 +280,20 @@ cleanup() {
 }
 
 main() {
+    # shellcheck disable=SC3040 # busybox ash supports pipefail
+    set -euxo pipefail
+
+    CPU_POLICY_DIR=""
+    TEMP_ROM_DIR=""
+
+    nds_normalize_platform
+    nds_init_env
+
+    rm -f "$LOGS_PATH/NDS.txt"
+    exec >>"$LOGS_PATH/NDS.txt" 2>&1
+
+    echo "$0" "$@"
+
     echo "1" >/tmp/stay_awake
     trap "cleanup" EXIT INT TERM HUP QUIT
 
@@ -110,37 +305,30 @@ main() {
     mkdir -p "$EMU_DIR/backup"
     mkdir -p "$EMU_DIR/savestates"
 
-    cat "$SYSTEM_CPU_POLICY0/$CPU_SCALING_GOVERNOR" >"$TEMP_SCALING_FILE"
-    cat "$SYSTEM_CPU_POLICY0/$CPU_SCALING_MIN_FREQ" >"$TEMP_SCALING_MIN_FREQ"
-    cat "$SYSTEM_CPU_POLICY0/$CPU_SCALING_MAX_FREQ" >"$TEMP_SCALING_MAX_FREQ"
+    CPU_POLICY_DIR="$(nds_cpu_policy_dir)"
+    nds_cpu_save_state
 
     # Predefined cpu profile for drastic
     nds_cpu_configure ondemand
     nds_buffer_size_patch
 
-    if [ -d "$EMU_DIR/cheats" ]; then
-        if ls -A "$EMU_DIR/cheats" | grep -q .; then
-            mv "$EMU_DIR/cheats/*" "$NDS_MINUI_CHEAT/" || true
-        fi
-    fi
+    nds_seed_device_config "$(nds_device_profile "$PLATFORM" "${DEVICE:-}")"
+    nds_sav_format_patch
+
+    nds_migrate_cheats
 
     mount -o bind "$NDS_MINUI_SAVE" "$EMU_DIR/backup"
     mount -o bind "$NDS_MINUI_CHEAT" "$EMU_DIR/cheats"
     mount -o bind "$NDS_SHARE_USERDATA_DIR" "$EMU_DIR/savestates"
 
-    # Extract zip ROMs to a temp directory before launching
-    ROM_PATH="$*"
-    case "$(echo "$ROM_PATH" | tr '[:upper:]' '[:lower:]')" in
-        *.zip)
-            "$PACK_DIR/bin/unzip" -o "$ROM_PATH" -d "$TEMP_ROM_DIR"
-            ROM_PATH=$(find "$TEMP_ROM_DIR" -name "*.nds" | head -1)
-            ;;
-    esac
+    nds_resolve_rom_path "$*"
 
     # Trigger custom minui-power-control and launch the emulator, make sure to be in the current directory
     cd "$EMU_DIR"
-    minui-power-control drastic &
-    LD_PRELOAD=$EMU_DIR/libs/libadvdrastic.so "$EMU_DIR/drastic" "$ROM_PATH"
+    nds_start_power_control
+    LD_PRELOAD="$EMU_DIR/libs/libadvdrastic.so" "$EMU_DIR/drastic" "$NDS_ROM_PATH"
 }
 
-main "$@"
+if [ "${NDS_PAK_TEST:-}" != "1" ]; then
+    main "$@"
+fi

--- a/pak.json
+++ b/pak.json
@@ -6,10 +6,12 @@
   "repo_url": "https://github.com/josegonzalez/minui-nintendo-ds-pak",
   "release_filename": "NDS.pak.zip",
   "platforms": [
+    "h700",
     "tg5040",
     "tg5050"
   ],
   "update_ignore": [
+    "drastic/config/drastic.cf2",
     "drastic/config/drastic.cfg",
     "drastic/resources/settings.json"
   ],

--- a/test/launch.bats
+++ b/test/launch.bats
@@ -1,0 +1,431 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export REPO_DIR
+
+    SDCARD_PATH="$BATS_TEST_TMPDIR/SDCARD"
+    export SDCARD_PATH
+    export PLATFORM="tg5040"
+    export USERDATA_PATH="$SDCARD_PATH/.userdata/$PLATFORM"
+    export SHARED_USERDATA_PATH="$SDCARD_PATH/.userdata/shared"
+    export LOGS_PATH="$USERDATA_PATH/logs"
+
+    export NDS_PAK_TEST=1
+    # shellcheck disable=SC1091
+    . "$REPO_DIR/launch.sh"
+}
+
+# Build a minimal pak tree with the real DraStic device profiles in place.
+fake_pak() {
+    unset DEVICE
+    PLATFORM="${1:-tg5040}"
+    [ -z "${2:-}" ] || DEVICE="$2"
+    export PLATFORM DEVICE
+    USERDATA_PATH="$SDCARD_PATH/.userdata/$PLATFORM"
+    export USERDATA_PATH
+
+    pak_dir="$SDCARD_PATH/Emus/$PLATFORM/NDS.pak"
+    mkdir -p "$pak_dir/drastic/config" "$pak_dir/drastic/resources" "$USERDATA_PATH"
+    cp -R "$REPO_DIR/drastic/devices" "$pak_dir/drastic/devices"
+    cp "$REPO_DIR/drastic/config/drastic.cfg" "$pak_dir/drastic/config/drastic.cfg"
+    cp "$REPO_DIR/drastic/config/drastic.cf2" "$pak_dir/drastic/config/drastic.cf2"
+    cp "$REPO_DIR/drastic/resources/settings.json" "$pak_dir/drastic/resources/settings.json"
+
+    nds_init_env
+    mkdir -p "$NDS_USERDATA_DIR"
+}
+
+config_value() {
+    awk -F' *= *' -v key="$1" '$1 == key { print $2 }' "$EMU_DIR/config/drastic.cfg"
+}
+
+@test "tg3040 without a device is normalized to a tg5040 brick" {
+    PLATFORM="tg3040"
+    unset DEVICE
+    nds_normalize_platform
+    [ "$PLATFORM" = "tg5040" ]
+    [ "$DEVICE" = "brick" ]
+}
+
+@test "tg3040 with a device is left alone" {
+    PLATFORM="tg3040"
+    DEVICE="something"
+    nds_normalize_platform
+    [ "$PLATFORM" = "tg3040" ]
+    [ "$DEVICE" = "something" ]
+}
+
+@test "trimui devices map onto their drastic profiles" {
+    [ "$(nds_device_profile tg5040 brick)" = "trimui-brick" ]
+    [ "$(nds_device_profile tg5040 brickpro)" = "trimui-brick" ]
+    [ "$(nds_device_profile tg5040 smartpro)" = "trimui-smart-pro" ]
+    [ "$(nds_device_profile tg5050 smartpros)" = "trimui-smart-pro" ]
+    [ "$(nds_device_profile tg5050 '')" = "trimui-smart-pro" ]
+}
+
+@test "an unknown trimui device keeps the shipped brick profile" {
+    [ "$(nds_device_profile tg5040 '')" = "trimui-brick" ]
+    [ "$(nds_device_profile tg5040 unreleased)" = "trimui-brick" ]
+}
+
+@test "h700 devices map onto their drastic profiles" {
+    [ "$(nds_device_profile h700 rg28xx)" = "rg28xx" ]
+    [ "$(nds_device_profile h700 rg35xxsp)" = "rg35xx-sp" ]
+    [ "$(nds_device_profile h700 rg40xxv)" = "rg40xx-v" ]
+    [ "$(nds_device_profile h700 rgcubexx)" = "rg-cubexx" ]
+}
+
+@test "h700 devices without a profile fall back by analog stick layout" {
+    [ "$(nds_device_profile h700 rg40xxh)" = "rg40xx-h" ]
+    [ "$(nds_device_profile h700 rg35xxh)" = "rg40xx-h" ]
+    [ "$(nds_device_profile h700 rg35xxpro)" = "rg40xx-h" ]
+    [ "$(nds_device_profile h700 rg34xxsp)" = "rg40xx-h" ]
+
+    [ "$(nds_device_profile h700 rg35xxplus)" = "rg35xx-sp" ]
+    [ "$(nds_device_profile h700 rg34xx)" = "rg35xx-sp" ]
+    [ "$(nds_device_profile h700 rgsp)" = "rg35xx-sp" ]
+    [ "$(nds_device_profile h700 '')" = "rg35xx-sp" ]
+}
+
+@test "every profile the mapping can return exists in the pak" {
+    for device in '' brick brickpro smartpro; do
+        [ -d "$REPO_DIR/drastic/devices/$(nds_device_profile tg5040 "$device")" ]
+    done
+    for device in '' smartpros; do
+        [ -d "$REPO_DIR/drastic/devices/$(nds_device_profile tg5050 "$device")" ]
+    done
+    for device in '' rg28xx rg34xx rg34xxsp rg35xxplus rg35xxh rg35xxpro rg35xxsp rg40xxh rg40xxv rgcubexx rgsp; do
+        [ -d "$REPO_DIR/drastic/devices/$(nds_device_profile h700 "$device")" ]
+    done
+}
+
+@test "seeding installs the profile config and records the device" {
+    fake_pak h700 rg40xxv
+
+    nds_seed_device_config rg40xx-v
+
+    [ "$(cat "$NDS_DEVICE_FILE")" = "rg40xx-v" ]
+    run diff "$EMU_DIR/config/drastic.cfg" "$EMU_DIR/devices/rg40xx-v/config/drastic.cfg"
+    [ "$status" -eq 0 ]
+    run diff "$EMU_DIR/config/drastic.cf2" "$EMU_DIR/devices/rg40xx-v/config/drastic.cf2"
+    [ "$status" -eq 0 ]
+}
+
+@test "seeding backs up the config it replaces" {
+    fake_pak h700 rg40xxv
+
+    echo "custom" >"$EMU_DIR/config/drastic.cfg"
+    nds_seed_device_config rg40xx-v
+
+    [ "$(cat "$NDS_USERDATA_DIR/drastic.cfg.bak")" = "custom" ]
+}
+
+@test "seeding copies a profile settings.json when there is one" {
+    fake_pak h700 rg28xx
+
+    nds_seed_device_config rg28xx
+
+    run grep -q display_rotate "$EMU_DIR/resources/settings.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "seeding leaves the shipped settings.json alone without a profile one" {
+    fake_pak h700 rg40xxv
+
+    nds_seed_device_config rg40xx-v
+
+    run diff "$EMU_DIR/resources/settings.json" "$REPO_DIR/drastic/resources/settings.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "seeding does not run again for the same device" {
+    fake_pak h700 rg40xxv
+
+    nds_seed_device_config rg40xx-v
+    echo "remapped" >"$EMU_DIR/config/drastic.cfg"
+    nds_seed_device_config rg40xx-v
+
+    [ "$(cat "$EMU_DIR/config/drastic.cfg")" = "remapped" ]
+}
+
+@test "seeding runs again when the device changes" {
+    fake_pak h700 rg40xxv
+
+    nds_seed_device_config rg40xx-v
+    echo "remapped" >"$EMU_DIR/config/drastic.cfg"
+    nds_seed_device_config rg-cubexx
+
+    [ "$(cat "$NDS_DEVICE_FILE")" = "rg-cubexx" ]
+    run diff "$EMU_DIR/config/drastic.cfg" "$EMU_DIR/devices/rg-cubexx/config/drastic.cfg"
+    [ "$status" -eq 0 ]
+}
+
+@test "seeding an unknown profile keeps the shipped config" {
+    fake_pak h700 rg40xxv
+
+    nds_seed_device_config nonexistent
+
+    [ ! -f "$NDS_DEVICE_FILE" ]
+    run diff "$EMU_DIR/config/drastic.cfg" "$REPO_DIR/drastic/config/drastic.cfg"
+    [ "$status" -eq 0 ]
+}
+
+@test "sav format is forced on so saves land in Saves/NDS" {
+    fake_pak h700 rg35xxsp
+
+    nds_seed_device_config rg35xx-sp
+    [ "$(config_value backup_use_sav_format)" = "0" ]
+
+    nds_sav_format_patch
+    [ "$(config_value backup_use_sav_format)" = "1" ]
+}
+
+@test "sav format patching leaves the rest of the config untouched" {
+    fake_pak h700 rg35xxsp
+
+    nds_seed_device_config rg35xx-sp
+    before="$(grep -cv backup_use_sav_format "$EMU_DIR/config/drastic.cfg")"
+    nds_sav_format_patch
+    after="$(grep -cv backup_use_sav_format "$EMU_DIR/config/drastic.cfg")"
+
+    [ "$before" = "$after" ]
+    [ "$(config_value screen_orientation)" = "0" ]
+}
+
+@test "setting a config key rewrites only that key" {
+    fake_pak tg5040 brick
+
+    before="$(wc -l <"$EMU_DIR/config/drastic.cfg")"
+    orientation="$(config_value screen_orientation)"
+    nds_config_set "$EMU_DIR/config/drastic.cfg" frame_interval 47619
+
+    [ "$(config_value frame_interval)" = "47619" ]
+    [ "$(config_value screen_orientation)" = "$orientation" ]
+    [ "$(wc -l <"$EMU_DIR/config/drastic.cfg")" = "$before" ]
+}
+
+@test "setting a config key does not add one that is absent" {
+    fake_pak tg5040 brick
+
+    nds_config_set "$EMU_DIR/config/drastic.cfg" not_a_real_key 1
+
+    run grep -q not_a_real_key "$EMU_DIR/config/drastic.cfg"
+    [ "$status" -ne 0 ]
+}
+
+@test "the cpu policy directory prefers policy0" {
+    policy="$BATS_TEST_TMPDIR/policy0"
+    percpu="$BATS_TEST_TMPDIR/cpu0"
+    mkdir -p "$policy" "$percpu"
+    echo "1008000 1200000" >"$policy/scaling_available_frequencies"
+    echo "1008000 1200000" >"$percpu/scaling_available_frequencies"
+    NDS_CPU_POLICY_DIRS="$policy $percpu"
+
+    [ "$(nds_cpu_policy_dir)" = "$policy" ]
+}
+
+@test "the cpu policy directory falls back to the per cpu path" {
+    policy="$BATS_TEST_TMPDIR/policy0"
+    percpu="$BATS_TEST_TMPDIR/cpu0"
+    mkdir -p "$policy" "$percpu"
+    echo "1008000 1200000" >"$percpu/scaling_available_frequencies"
+    NDS_CPU_POLICY_DIRS="$policy $percpu"
+
+    [ "$(nds_cpu_policy_dir)" = "$percpu" ]
+}
+
+@test "the cpu policy directory is empty when cpufreq is unavailable" {
+    NDS_CPU_POLICY_DIRS="$BATS_TEST_TMPDIR/missing"
+
+    [ -z "$(nds_cpu_policy_dir)" ]
+}
+
+@test "cpu settings survive a save and restore round trip" {
+    fake_pak tg5040 brick
+    CPU_POLICY_DIR="$BATS_TEST_TMPDIR/policy0"
+    mkdir -p "$CPU_POLICY_DIR"
+    echo "1008000 1200000 1608000" >"$CPU_POLICY_DIR/scaling_available_frequencies"
+    echo "schedutil" >"$CPU_POLICY_DIR/scaling_governor"
+    echo "1008000" >"$CPU_POLICY_DIR/scaling_min_freq"
+    echo "1200000" >"$CPU_POLICY_DIR/scaling_max_freq"
+
+    nds_cpu_save_state
+    nds_cpu_configure ondemand
+    [ "$(cat "$CPU_POLICY_DIR/scaling_governor")" = "ondemand" ]
+    [ "$(cat "$CPU_POLICY_DIR/scaling_min_freq")" = "1008000" ]
+    [ "$(cat "$CPU_POLICY_DIR/scaling_max_freq")" = "1608000" ]
+
+    nds_cpu_restore_state
+    [ "$(cat "$CPU_POLICY_DIR/scaling_governor")" = "schedutil" ]
+    [ "$(cat "$CPU_POLICY_DIR/scaling_min_freq")" = "1008000" ]
+    [ "$(cat "$CPU_POLICY_DIR/scaling_max_freq")" = "1200000" ]
+    [ ! -f "$TEMP_SCALING_FILE" ]
+}
+
+@test "cpu save skips settings the kernel does not expose" {
+    fake_pak tg5040 brick
+    CPU_POLICY_DIR="$BATS_TEST_TMPDIR/policy0"
+    mkdir -p "$CPU_POLICY_DIR"
+    echo "schedutil" >"$CPU_POLICY_DIR/scaling_governor"
+
+    run nds_cpu_save_state
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEMP_SCALING_FILE")" = "schedutil" ]
+    [ ! -f "$TEMP_SCALING_MIN_FREQ" ]
+
+    run nds_cpu_restore_state
+    [ "$status" -eq 0 ]
+}
+
+@test "cpu state functions are inert without a policy directory" {
+    fake_pak tg5040 brick
+    CPU_POLICY_DIR=""
+
+    run nds_cpu_save_state
+    [ "$status" -eq 0 ]
+    run nds_cpu_restore_state
+    [ "$status" -eq 0 ]
+}
+
+@test "the performance governor leaves the minimum frequency alone" {
+    fake_pak tg5040 brick
+    CPU_POLICY_DIR="$BATS_TEST_TMPDIR/policy0"
+    mkdir -p "$CPU_POLICY_DIR"
+    echo "1008000 1200000 1608000" >"$CPU_POLICY_DIR/scaling_available_frequencies"
+    echo "1200000" >"$CPU_POLICY_DIR/scaling_min_freq"
+
+    nds_cpu_configure performance
+
+    [ "$(cat "$CPU_POLICY_DIR/scaling_governor")" = "performance" ]
+    [ "$(cat "$CPU_POLICY_DIR/scaling_min_freq")" = "1200000" ]
+    [ "$(cat "$CPU_POLICY_DIR/scaling_max_freq")" = "1608000" ]
+}
+
+@test "an unknown governor is reported and changes nothing" {
+    fake_pak tg5040 brick
+    CPU_POLICY_DIR="$BATS_TEST_TMPDIR/policy0"
+    mkdir -p "$CPU_POLICY_DIR"
+    echo "1008000 1608000" >"$CPU_POLICY_DIR/scaling_available_frequencies"
+
+    run nds_cpu_configure conservative
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Unsupported governor: conservative"* ]]
+    [ ! -f "$CPU_POLICY_DIR/scaling_governor" ]
+}
+
+@test "cpu tuning is skipped without a policy directory" {
+    CPU_POLICY_DIR=""
+
+    run nds_cpu_configure ondemand
+    [ "$status" -eq 0 ]
+}
+
+@test "the preferred frequency is the fastest one within the limit" {
+    [ "$(nds_cpu_prefer_freq "408000 1008000 1608000 1800000")" = "1608000" ]
+    [ "$(nds_cpu_prefer_freq "408000 1008000 1512000")" = "1512000" ]
+}
+
+@test "the preferred frequency falls back to the maximum when nothing qualifies" {
+    [ "$(nds_cpu_prefer_freq "1800000 2000000")" = "2000000" ]
+}
+
+@test "the minimum frequency does not depend on list order" {
+    [ "$(nds_cpu_min_freq "1800000 408000 1008000")" = "408000" ]
+    [ "$(nds_cpu_min_freq "408000 1008000 1800000")" = "408000" ]
+}
+
+@test "a plain rom path is passed through untouched" {
+    fake_pak tg5040 brick
+
+    nds_resolve_rom_path "$SDCARD_PATH/Roms/NDS/Game.nds"
+
+    [ "$NDS_ROM_PATH" = "$SDCARD_PATH/Roms/NDS/Game.nds" ]
+    [ -z "$TEMP_ROM_DIR" ]
+}
+
+@test "a zipped rom is extracted and the nds inside it is returned" {
+    fake_pak tg5040 brick
+    command -v unzip >/dev/null || skip "unzip is not installed"
+    mkdir -p "$PACK_DIR/bin"
+    ln -sf "$(command -v unzip)" "$PACK_DIR/bin/unzip"
+
+    mkdir -p "$SDCARD_PATH/Roms/NDS"
+    (cd "$BATS_TEST_TMPDIR" && echo rom >Game.nds && zip -q Game.zip Game.nds)
+    mv "$BATS_TEST_TMPDIR/Game.zip" "$SDCARD_PATH/Roms/NDS/Game.zip"
+
+    TEMP_ROM_DIR=""
+    nds_resolve_rom_path "$SDCARD_PATH/Roms/NDS/Game.zip"
+
+    [ -n "$TEMP_ROM_DIR" ]
+    [ "$NDS_ROM_PATH" = "$TEMP_ROM_DIR/Game.nds" ]
+    rm -rf "$TEMP_ROM_DIR"
+}
+
+@test "an uppercase zip extension is still extracted" {
+    fake_pak tg5040 brick
+    command -v unzip >/dev/null || skip "unzip is not installed"
+    mkdir -p "$PACK_DIR/bin"
+    ln -sf "$(command -v unzip)" "$PACK_DIR/bin/unzip"
+
+    mkdir -p "$SDCARD_PATH/Roms/NDS"
+    (cd "$BATS_TEST_TMPDIR" && echo rom >Game.nds && zip -q Game.ZIP Game.nds)
+    mv "$BATS_TEST_TMPDIR/Game.ZIP" "$SDCARD_PATH/Roms/NDS/Game.ZIP"
+
+    TEMP_ROM_DIR=""
+    nds_resolve_rom_path "$SDCARD_PATH/Roms/NDS/Game.ZIP"
+
+    [ "$NDS_ROM_PATH" = "$TEMP_ROM_DIR/Game.nds" ]
+    rm -rf "$TEMP_ROM_DIR"
+}
+
+@test "cheats are migrated out before the bind mount" {
+    fake_pak tg5040 brick
+
+    mkdir -p "$EMU_DIR/cheats" "$NDS_MINUI_CHEAT"
+    echo cheat >"$EMU_DIR/cheats/Game.cht"
+    nds_migrate_cheats
+
+    [ -f "$NDS_MINUI_CHEAT/Game.cht" ]
+    [ ! -f "$EMU_DIR/cheats/Game.cht" ]
+}
+
+@test "cheat migration is a no-op for an empty directory" {
+    fake_pak tg5040 brick
+
+    mkdir -p "$EMU_DIR/cheats" "$NDS_MINUI_CHEAT"
+    run nds_migrate_cheats
+    [ "$status" -eq 0 ]
+}
+
+@test "the bundled libraries come before the system ones" {
+    fake_pak h700 rg40xxh
+    export LD_LIBRARY_PATH="/system/lib"
+    nds_init_env
+
+    case "$LD_LIBRARY_PATH" in
+    "$EMU_DIR/libs":*"/system/lib"*) ;;
+    *) return 1 ;;
+    esac
+}
+
+@test "alsa overrides are only exported on tg5040" {
+    fake_pak h700 rg40xxh
+    unset ALSA_CONFIG_PATH ALSA_ASOUNDRC
+
+    run nds_buffer_size_patch
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Unsupported platform: h700"* ]]
+
+    fake_pak tg5040 brick
+    nds_buffer_size_patch
+    [ "$ALSA_CONFIG_PATH" = "$EMU_DIR/devices/trimui-brick/alsa/nds_alsa.conf" ]
+    [ "$ALSA_ASOUNDRC" = "$EMU_DIR/devices/trimui-brick/alsa/.asoundrc" ]
+}
+
+@test "power control is started only on the platforms it supports" {
+    PLATFORM="h700"
+    run nds_start_power_control
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"does not support h700"* ]]
+}


### PR DESCRIPTION
The pak now claims the `h700` platform alongside `tg5040` and `tg5050` so it is offered on Anbernic RG XX handhelds. Advanced DraStic ships a configuration per device and the pak previously installed the Trimui Brick one everywhere, which leaves every other device with the wrong button mapping, so the launcher now picks the matching profile on first launch and records the choice. Reading the cpufreq policy no longer aborts the launcher on kernels that expose it only under the per cpu path.

The h700 platform comes from NextUI, which is still reviewing it in LoveRetro/NextUI#807, so the emulator itself has not been exercised on that hardware yet. Trimui Brick behaviour is unchanged: the profile it seeds is byte identical to the config the pak shipped before.

Closes #80.
